### PR TITLE
[FIX] compute warning about inconsistency + add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# dotfiles
+.*
+!.gitignore
+!.github
+!.mailmap
+# compiled python files
+*.py[co]
+__pycache__/

--- a/models/sale_order.py
+++ b/models/sale_order.py
@@ -10,7 +10,7 @@ class SaleOrder(models.Model):
         ('in progress', 'In Progress'),
         ('partially finished', 'Partially Finished'),
         ('finished', 'Finished'),
-    ], string='Task Status', compute='_compute_task_status', store=True)
+    ], string='Task Status', compute='_compute_task_status', compute_sudo=False, store=True)
 
     @api.depends('tasks_ids', 'tasks_ids.stage_id', 'tasks_ids.is_closed')
     def _compute_task_status(self):


### PR DESCRIPTION
- There is a mismatch about the compute_sudo between this compute overide and its super. While neither are set as compute_sudo=True and they should be the same, since one of store=True, it actually makes the compute_sudo=True silently. Need to set it to False to align it with its super value

- Add gitignore, otherwise all python cache files are added to the diff and commit(s).