### PR TITLE
[FIX] wrong compute method is called

### DIFF
--- a/models/sale_order.py
+++ b/models/sale_order.py
@@ -10,7 +10,7 @@ class SaleOrder(models.Model):
         ('in progress', 'In Progress'),
         ('partially finished', 'Partially Finished'),
         ('finished', 'Finished'),
-    ], string='Task Status', compute='_compute_task_status', compute_sudo=False, store=True)
+    ], string='Task Status', compute='_compute_tasks_ids', compute_sudo=False, store=True)
 
     @api.depends('order_line.product_id.project_id')
     def _compute_tasks_ids(self):


### PR DESCRIPTION
Not sure how this happened. There is a weird history of commits including some branch merged inside another:
- Merge pull request 2 from sbuhl/main-fix-compute-warning-shortcut
- Merge branch 'main' into main-fix-compute-warning-shortcut
- [FIX] compute warning about inconsistency + add gitignore
- Merge pull request 1 from sbuhl/main-fix-compute-error-shortcut
- Remove .gitignore and update version in manifest
- [FIX] correct compute and correct inherit
- first commit

This should simply be:
- [FIX] compute warning about inconsistency + add gitignore
- Remove .gitignore and update version in manifest
- [FIX] correct compute and correct inherit
- first commit