### PR TITLE
Gse access right technicians

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 # compiled python files
 *.py[co]
 __pycache__/
+/tests

--- a/__manifest__.py
+++ b/__manifest__.py
@@ -10,9 +10,10 @@
         Display the status of a task. 
         Open | Closed
     """,
-    'depends': ['sale_project'],
+    'depends': ['base', 'sale_project', 'sale'],
     'data': [
         'views/gse_sale_order_view.xml',
+        'security/security.xml',
     ],
     'installable': True,
     

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,5 @@
 # -*- coding: utf-8 -*-
 
 from . import sale_order
+from . import project
+from . import res_users

--- a/models/project.py
+++ b/models/project.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+from odoo import api, models
+
+class ProjectTask(models.Model):
+    _inherit = "project.task"
+
+    def after_save(self):
+        users = self.env['res.users'].search([])
+        for user in users:
+            user._compute_task_ids()   
+
+    def write(self, vals):
+        result = super(ProjectTask, self).write(vals)
+        self.after_save()
+        return result
+    
+    

--- a/models/res_users.py
+++ b/models/res_users.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields,api
+
+
+class Users(models.Model):
+    _name = 'res.users'
+    _inherit = [
+        'res.users',
+        'mail.thread',
+    ]
+
+    stored_sale_orders = fields.Many2many(
+        'sale.order',
+        'bk_sale_order_user_rel',
+        'user_id',
+        'sale_order_id',
+        string='Sale Orders')
+    tasks_ids = fields.Many2many('project.task', string='Tasks For Status', compute='_compute_task_ids')
+    
+    @api.depends('tasks_ids')
+    def _compute_task_ids(self):
+        for user in self:
+            tasks = self.env['project.task'].search([])
+            origin = user.id if user.id else user.id.origin
+            assigned_tasks = tasks.filtered(lambda task: origin in task.user_ids.ids and task.sale_order_id) 
+            user.tasks_ids = [(6, 0, assigned_tasks.ids)] 
+            sale_order_ids = set(task.sale_order_id.id for task in user.tasks_ids) 
+            user.stored_sale_orders = [(6, 0, list(sale_order_ids))]
+            

--- a/security/security.xml
+++ b/security/security.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">       
+        <record id="group_sale_task_technician" model="res.groups">
+            <field name="name">Technician GSE</field>
+            <field name="category_id" ref="base.module_category_sales_sales"/>
+            <field name="implied_ids" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
+        </record>
+
+        <record id="sale_order_line_assigned_rule" model="ir.rule">
+            <field name="name">Assigned Order lines BENKIS</field>
+            <field ref="sale.model_sale_order_line" name="model_id"/>
+            <field name="domain_force">['|',('order_id.id', 'in',  user.stored_sale_orders.ids), ('salesman_id','=',user.id)]</field>
+            <field name="groups" eval="[(4, ref('group_sale_task_technician'))]"/>
+        </record>
+
+        <record id="sale_order_assigned_rule" model="ir.rule">
+            <field name="name">Assigned Orders BENKIS</field>
+            <field ref="model_sale_order" name="model_id"/>
+            <field name="domain_force">['|',('id', 'in',  user.stored_sale_orders.ids), ('user_id', '=', user.id)]</field>
+            <field name="groups" eval="[(4, ref('group_sale_task_technician'))]"/>
+        </record>
+    </data>
+
+</odoo>


### PR DESCRIPTION
### 🗒️  Rationale
We currently spend a significant amount of time adding users as technicians to grant them access to tasks, which is not a scalable solution.

### Specification

 ####  🆘  Current situation:

 When a vendor validates a sales order that generates a task, the technician does not have access to the task. This is because sales orders are set as private by default.

#### ♻️ Desired situation: 

Technicians should be able to access the tasks created by sales orders from the vendor, but should not have access to the sales orders itself.

### 🕐  Current behavior

The current behavior is as follows.
1. If a user is assigned to a task, the information is not saved in the database directly, it required to Go to the User view and save them.
As shown in this attached [video](https://drive.google.com/file/d/14FPgw6khlUSwBnfjCX2M6rpo8GSu9c_O/view?usp=sharing), when `Putin` has been assigned to the task he wasn't direct getting the access to the task, I have to go in the User view form view to save it manually then access was granted 